### PR TITLE
Remove unserscore

### DIFF
--- a/OTVideoPlayer/helpers.py
+++ b/OTVideoPlayer/helpers.py
@@ -51,7 +51,7 @@ def _get_datetime_from_filename(
     Returns:
         str: datetime
     """
-    regex = "_([0-9]{4,4}-[0-9]{2,2}-[0-9]{2,2}_[0-9]{2,2}-[0-9]{2,2}-[0-9]{2,2})"
+    regex = "([0-9]{4,4}-[0-9]{2,2}-[0-9]{2,2}_[0-9]{2,2}-[0-9]{2,2}-[0-9]{2,2})"
     match = re.search(regex, filename)
     if not match:
         return dt.datetime.strptime(epoch_datetime, "%Y-%m-%d_%H-%M-%S")

--- a/OTVideoPlayer/helpers.py
+++ b/OTVideoPlayer/helpers.py
@@ -41,15 +41,15 @@ def _get_datetime_from_filename(
     filename: str, epoch_datetime="1970-01-01_00-00-00"
 ) -> str:
     """Get date and time from file name.
-    Searches for "_yyyy-mm-dd_hh-mm-ss".
-    Returns "yyyy-mm-dd_hh-mm-ss".
+    Searches for "yyyy-mm-dd_hh-mm-ss".
+    Returns datetime object.
 
     Args:
         filename (str): filename with expression
         epoch_datetime (str): Unix epoch (00:00:00 on 1 January 1970)
 
     Returns:
-        str: datetime
+        dt.datetime: datetime object
     """
     regex = "([0-9]{4,4}-[0-9]{2,2}-[0-9]{2,2}_[0-9]{2,2}-[0-9]{2,2}-[0-9]{2,2})"
     match = re.search(regex, filename)


### PR DESCRIPTION
Makes reading time from filename position-agnostic (now it doesnt matter if time is at beginning or end of filenames stem)